### PR TITLE
Build WordPress-powered news front

### DIFF
--- a/app/Helpers/Wordpress.php
+++ b/app/Helpers/Wordpress.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Helpers;
+
+class Wordpress
+{
+    public static function image(array $post): string
+    {
+        return $post['_embedded']['wp:featuredmedia'][0]['source_url'] ?? 'https://via.placeholder.com/800x400?text=No+Image';
+    }
+
+    public static function category(array $post): string
+    {
+        return $post['_embedded']['wp:term'][0][0]['name'] ?? 'Sin categor\u00eda';
+    }
+
+    public static function tags(array $post): array
+    {
+        if (isset($post['_embedded']['wp:term'][1])) {
+            return array_map(fn($tag) => $tag['name'], $post['_embedded']['wp:term'][1]);
+        }
+        return [];
+    }
+}

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
+
+class HomeController extends Controller
+{
+    public function index()
+    {
+        $url = rtrim(config('services.wordpress.url'), '/').'/wp-json/wp/v2/posts?_embed';
+        $response = Http::get($url);
+        $posts = $response->successful() ? $response->json() : [];
+
+        return view('home', [
+            'posts' => $posts,
+        ]);
+    }
+}

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Carbon;
+
+class PostController extends Controller
+{
+    public function show(string $slug)
+    {
+        $url = rtrim(config('services.wordpress.url'), '/')."/wp-json/wp/v2/posts?slug={$slug}&_embed";
+        $response = Http::get($url);
+        $data = $response->successful() ? $response->json() : [];
+        $post = $data[0] ?? null;
+
+        abort_unless($post, 404);
+
+        return view('post', [
+            'post' => $post,
+        ]);
+    }
+}

--- a/config/services.php
+++ b/config/services.php
@@ -35,4 +35,8 @@ return [
         ],
     ],
 
+    'wordpress' => [
+        'url' => env('WORDPRESS_URL', 'https://mydomain.com/wp'),
+    ],
+
 ];

--- a/public/js/dark-mode.js
+++ b/public/js/dark-mode.js
@@ -1,0 +1,12 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const toggle = document.getElementById('theme-toggle');
+    if (!toggle) return;
+    const html = document.documentElement;
+    if (localStorage.getItem('dark-mode') === 'true') {
+        html.classList.add('dark');
+    }
+    toggle.addEventListener('click', () => {
+        html.classList.toggle('dark');
+        localStorage.setItem('dark-mode', html.classList.contains('dark'));
+    });
+});

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -1,0 +1,47 @@
+@extends('layouts.app')
+
+@section('content')
+    <div class="container mx-auto px-4 py-6 space-y-6">
+        @php $first = $posts[0] ?? null; @endphp
+        @if($first)
+            <div class="flex flex-col md:flex-row bg-white dark:bg-gray-800 rounded-lg shadow overflow-hidden">
+                <img src="{{ App\Helpers\Wordpress::image($first) }}" alt="{{ $first['title']['rendered'] }}" class="w-full md:w-1/2 h-64 object-cover">
+                <div class="p-4 flex flex-col">
+                    <span class="text-sm text-blue-600 font-semibold">{{ App\Helpers\Wordpress::category($first) }}</span>
+                    <h2 class="text-2xl font-bold mb-2">{!! $first['title']['rendered'] !!}</h2>
+                    <p class="text-sm text-gray-600 dark:text-gray-300 flex-1">{{ \Illuminate\Support\Str::limit(strip_tags($first['excerpt']['rendered']), 150) }}</p>
+                    <a href="{{ url('/noticia/'.$first['slug']) }}" class="mt-4 text-blue-500 hover:underline">Leer más</a>
+                </div>
+            </div>
+        @endif
+
+        <div class="overflow-x-auto">
+            <div class="flex space-x-2">
+                @php $categories = collect($posts)->map(fn($p) => App\Helpers\Wordpress::category($p))->unique(); @endphp
+                @foreach($categories as $cat)
+                    <span class="px-3 py-1 bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-300 rounded-full text-sm">{{ $cat }}</span>
+                @endforeach
+            </div>
+        </div>
+
+        <div class="grid md:grid-cols-3 gap-6">
+            @foreach($posts as $index => $post)
+                @if($index == 0) @continue @endif
+                <div class="bg-white dark:bg-gray-800 rounded-lg shadow overflow-hidden flex flex-col">
+                    <img src="{{ App\Helpers\Wordpress::image($post) }}" alt="{{ $post['title']['rendered'] }}" class="h-48 w-full object-cover">
+                    <div class="p-4 flex flex-col flex-1">
+                        <span class="text-xs bg-blue-500 text-white rounded px-2 py-1 self-start">{{ App\Helpers\Wordpress::category($post) }}</span>
+                        <h3 class="text-lg font-semibold mt-2">{!! $post['title']['rendered'] !!}</h3>
+                        <p class="text-sm text-gray-600 dark:text-gray-300 mb-4 flex-1">{{ \Illuminate\Support\Str::limit(strip_tags($post['excerpt']['rendered']), 100) }}</p>
+                        <div class="flex flex-wrap gap-1 text-xs mb-2">
+                            @foreach(App\Helpers\Wordpress::tags($post) as $tag)
+                                <span class="text-blue-500">#{{ $tag }}</span>
+                            @endforeach
+                        </div>
+                        <a href="{{ url('/noticia/'.$post['slug']) }}" class="text-blue-500 hover:underline mt-auto">Leer más</a>
+                    </div>
+                </div>
+            @endforeach
+        </div>
+    </div>
+@endsection

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="es" class="h-full">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ $title ?? 'NoticiasDM' }}</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+        tailwind.config = { darkMode: 'class' };
+    </script>
+</head>
+<body class="bg-gray-50 dark:bg-gray-900 text-gray-800 dark:text-gray-100 transition-colors min-h-full flex flex-col">
+    <nav class="bg-white dark:bg-gray-800 shadow">
+        <div class="container mx-auto px-4 py-3 flex items-center justify-between">
+            <div class="font-bold text-xl text-blue-600">NoticiasDM</div>
+            <div class="hidden md:flex items-center space-x-4">
+                <input type="search" placeholder="Buscar..." class="border rounded px-2 py-1 text-sm">
+                <a href="#" class="text-gray-700 dark:text-gray-200">Escritores</a>
+                <a href="#" class="text-gray-700 dark:text-gray-200">Escritor</a>
+                <button id="theme-toggle" class="text-gray-700 dark:text-gray-200 focus:outline-none">🌙</button>
+            </div>
+            <button class="md:hidden text-gray-700 dark:text-gray-200">☰</button>
+        </div>
+    </nav>
+    <main class="flex-1">
+        @yield('content')
+    </main>
+    <script src="{{ asset('js/dark-mode.js') }}"></script>
+</body>
+</html>

--- a/resources/views/post.blade.php
+++ b/resources/views/post.blade.php
@@ -1,0 +1,20 @@
+@extends('layouts.app')
+
+@section('content')
+    <div class="container mx-auto px-4 py-6">
+        <div class="max-w-3xl mx-auto bg-white dark:bg-gray-800 rounded-lg shadow p-6">
+            <h1 class="text-3xl font-bold mb-4">{!! $post['title']['rendered'] !!}</h1>
+            <img src="{{ App\Helpers\Wordpress::image($post) }}" alt="{{ $post['title']['rendered'] }}" class="w-full h-64 object-cover rounded mb-4">
+            <div class="text-sm text-gray-600 dark:text-gray-400 mb-4">
+                <span>{{ App\Helpers\Wordpress::category($post) }}</span>
+                <span class="mx-2">|</span>
+                <span>{{ $post['_embedded']['author'][0]['name'] ?? '' }}</span>
+                <span class="mx-2">|</span>
+                <span>{{ \Carbon\Carbon::parse($post['date'])->format('d M Y') }}</span>
+            </div>
+            <div class="prose dark:prose-invert max-w-none">
+                {!! $post['content']['rendered'] !!}
+            </div>
+        </div>
+    </div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,8 @@
 
 use Illuminate\Support\Facades\Route;
 
-Route::get('/', function () {
-    return view('welcome');
-});
+use App\Http\Controllers\HomeController;
+use App\Http\Controllers\PostController;
+
+Route::get('/', [HomeController::class, 'index'])->name('home');
+Route::get('/noticia/{slug}', [PostController::class, 'show'])->name('post.show');


### PR DESCRIPTION
## Summary
- configure WordPress endpoint
- create HomeController and PostController
- add helper for featured images, categories and tags
- new layout with Tailwind and dark mode toggle
- implement home and post pages
- add routes for homepage and single posts

## Testing
- `php -l app/Http/Controllers/HomeController.php`
- `php -l app/Http/Controllers/PostController.php`
- `php -l resources/views/home.blade.php`
- `php -l resources/views/post.blade.php`
- `php -l resources/views/layouts/app.blade.php`

------
https://chatgpt.com/codex/tasks/task_e_6885690ae94c8331a2e0d52b6f44ce50